### PR TITLE
Add callback to force refresh comments

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,3 +40,5 @@ Please note that you must you React with addons, so choose the appropriate built
 - **messageSentCallback** (`function`): a callback to know when a message has been sent
 - **timeDisplay** (`string`): the display format, either `ago` or `dateTime`, `ago` by default
 - **dateTimeFormat** (`string`): the dateTime format if **timeDisplay** is set to `dateTime`
+- **registerRefreshCommentsCallback** (`function`): method to register a refresh comment callback into parent
+- **unregisterRefreshCommentsCallback** (`function`): method to unregister the refresh comment callback from parent

--- a/README.md
+++ b/README.md
@@ -40,5 +40,5 @@ Please note that you must you React with addons, so choose the appropriate built
 - **messageSentCallback** (`function`): a callback to know when a message has been sent
 - **timeDisplay** (`string`): the display format, either `ago` or `dateTime`, `ago` by default
 - **dateTimeFormat** (`string`): the dateTime format if **timeDisplay** is set to `dateTime`
-- **registerRefreshCommentsCallback** (`function`): method to register a refresh comment callback into parent
-- **unregisterRefreshCommentsCallback** (`function`): method to unregister the refresh comment callback from parent
+- **registerRefreshCommentsMethod** (`function`): method to register the refresh comment method into parent
+- **unregisterRefreshCommentsMethod** (`function`): method to unregister the refresh comment method from parent

--- a/src/component/index.js
+++ b/src/component/index.js
@@ -28,7 +28,9 @@ const propTypes = {
     locale: PropTypes.string.isRequired,
     messageSentCallback: PropTypes.func,
     timeDisplay: PropTypes.oneOf(['ago', 'dateTime']),
-    dateTimeFormat: PropTypes.string
+    dateTimeFormat: PropTypes.string,
+    registerRefreshCommentsCallback: PropTypes.func,
+    unregisterRefreshCommentsCallback: PropTypes.func
 }
 
 const defaultProps = {
@@ -47,18 +49,27 @@ const defaultProps = {
     },
     locale: 'en',
     timeDisplay: 'ago',
-    dateTimeFormat: 'DD/MM/YYYY HH:mm'
+    dateTimeFormat: 'DD/MM/YYYY HH:mm',
+    registerRefreshCommentsCallback: undefined,
+    unregisterRefreshCommentsCallback: undefined
 }
 
 class Container extends Component {
-    _refreshComments() {
-        const { dispatch, concept, conceptId, apiRootUrl } = this.props;
-        dispatch(getComments(concept, conceptId, apiRootUrl));
+
+    constructor(props) {
+        super(props);
+
+        this._refreshComments = this._refreshComments.bind(this);
     }
 
     componentWillMount() {
+        const { dispatch, apiRootUrl, concept, conceptId, locale, registerRefreshCommentsCallback } = this.props;
+
+        if (registerRefreshCommentsCallback) {
+            registerRefreshCommentsCallback(this._refreshComments);
+        }
+
         moment.locale(this.props.locale);
-        const { dispatch, apiRootUrl, concept, conceptId } = this.props;
         dispatch(getComments(concept, conceptId, apiRootUrl));
     }
 
@@ -70,8 +81,19 @@ class Container extends Component {
     }
 
     componentWillUnmount() {
-        this.props.dispatch(clearComments());
+        const { dispatch, unregisterRefreshCommentsCallback } = this.props;
+
+        if (unregisterRefreshCommentsCallback) {
+            unregisterRefreshCommentsCallback();
+        }
+
+        dispatch(clearComments());
         clearInterval(this.refreshInterval);
+    }
+
+    _refreshComments() {
+        const { dispatch, concept, conceptId, apiRootUrl } = this.props;
+        dispatch(getComments(concept, conceptId, apiRootUrl));
     }
 
     render() {
@@ -82,7 +104,7 @@ class Container extends Component {
                     <div data-focus='title'>{this.props.texts.title}</div>
                     <div data-focus='last-update'>{isLoading ? this.props.texts.loading : `${this.props.texts.lastUpdate} ${moment(lastUpdate).fromNow()}`}</div>
                     <div data-focus='refresh'>
-                        <button className='mdl-button mdl-js-button mdl-button--fab mdl-button--colored mdl-button--raised' onClick={this._refreshComments.bind(this)}>
+                        <button className='mdl-button mdl-js-button mdl-button--fab mdl-button--colored mdl-button--raised' onClick={this._refreshComments}>
                             {isLoading ?
                                 <i className="fa fa-circle-o-notch fa-spin"></i>
                                 :

--- a/src/component/index.js
+++ b/src/component/index.js
@@ -29,8 +29,8 @@ const propTypes = {
     messageSentCallback: PropTypes.func,
     timeDisplay: PropTypes.oneOf(['ago', 'dateTime']),
     dateTimeFormat: PropTypes.string,
-    registerRefreshCommentsCallback: PropTypes.func,
-    unregisterRefreshCommentsCallback: PropTypes.func
+    registerRefreshCommentsMethod: PropTypes.func,
+    unregisterRefreshCommentsMethod: PropTypes.func
 }
 
 const defaultProps = {
@@ -50,8 +50,8 @@ const defaultProps = {
     locale: 'en',
     timeDisplay: 'ago',
     dateTimeFormat: 'DD/MM/YYYY HH:mm',
-    registerRefreshCommentsCallback: undefined,
-    unregisterRefreshCommentsCallback: undefined
+    registerRefreshCommentsMethod: undefined,
+    unregisterRefreshCommentsMethod: undefined
 }
 
 class Container extends Component {
@@ -63,10 +63,10 @@ class Container extends Component {
     }
 
     componentWillMount() {
-        const { dispatch, apiRootUrl, concept, conceptId, locale, registerRefreshCommentsCallback } = this.props;
+        const { dispatch, apiRootUrl, concept, conceptId, locale, registerRefreshCommentsMethod } = this.props;
 
-        if (registerRefreshCommentsCallback) {
-            registerRefreshCommentsCallback(this._refreshComments);
+        if (registerRefreshCommentsMethod) {
+            registerRefreshCommentsMethod(this._refreshComments);
         }
 
         moment.locale(this.props.locale);
@@ -81,10 +81,10 @@ class Container extends Component {
     }
 
     componentWillUnmount() {
-        const { dispatch, unregisterRefreshCommentsCallback } = this.props;
+        const { dispatch, unregisterRefreshCommentsMethod } = this.props;
 
-        if (unregisterRefreshCommentsCallback) {
-            unregisterRefreshCommentsCallback();
+        if (unregisterRefreshCommentsMethod) {
+            unregisterRefreshCommentsMethod();
         }
 
         dispatch(clearComments());


### PR DESCRIPTION
Fix issue #48 

## Solution

Add two props `registerRefreshCommentsMethod` and `unregisterRefreshCommentsMethod`.
They are used to register a method into a parent component to force refresh of components.

## Usage

Can be used like followed :

```jsx
    _refreshComments: undefined,

    registerRefreshCommentsMethod(method) {
        this._refreshComments = method;
    },

    unregisterRefreshCommentsMethod() {
        this._refreshComments = undefined;
    },

    refreshComments() {
        if (this._refreshComments) {
            this._refreshComments();
        }
    },

    [...]

    <FocusComments 
        {...props}
        registerRefreshCommentsMethod={this.registerRefreshCommentsMethod}
        unregisterRefreshCommentsMethod={this.unregisterRefreshCommentsMethod}
    />
```